### PR TITLE
Dependency cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-video-sys"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["luozijun <luozijun.assistant@gmail.com>", "michael.laifx <cihv2@163.com>"]
 description = "Bindings to CoreVideo.framework for macOS and iOS"
 license = "MIT"
@@ -16,19 +16,14 @@ objc = "0.2"
 core-foundation-sys = "0.8"
 
 [dependencies.metal]
-version = "0.20"
-features = ["private"]
-optional = true
-
-[dependencies.core-graphics]
-version = "0.22"
+version = "0.23"
 optional = true
 
 [features]
-default = [ "display_link", "metal" ]
+default = []
 all = [ "display_link", "direct3d", "io_suface", "opengl" ]
 
-display_link = [ "opengl", "core-graphics" ]
+display_link = [ "opengl" ]
 direct3d  = [ ]
 io_suface = [ ]
 opengl    = [ ]

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,6 +1,5 @@
 use libc::c_double;
 
-
 // https://developer.apple.com/documentation/corevideo/cvoptionflags?language=objc
 pub type CVOptionFlags = u64;
 pub type CVSMPTETimeType = u32;
@@ -8,21 +7,19 @@ pub type CVSMPTETimeFlags = u32;
 pub type CVTimeFlags = i32;
 pub type CVTimeStampFlags = u64;
 
+pub const kCVSMPTETimeType24: CVSMPTETimeType = 0;
+pub const kCVSMPTETimeType25: CVSMPTETimeType = 1;
+pub const kCVSMPTETimeType30Drop: CVSMPTETimeType = 2;
+pub const kCVSMPTETimeType30: CVSMPTETimeType = 3;
+pub const kCVSMPTETimeType2997: CVSMPTETimeType = 4;
+pub const kCVSMPTETimeType2997Drop: CVSMPTETimeType = 5;
+pub const kCVSMPTETimeType60: CVSMPTETimeType = 6;
+pub const kCVSMPTETimeType5994: CVSMPTETimeType = 7;
 
-pub const kCVSMPTETimeType24: CVSMPTETimeType        = 0;
-pub const kCVSMPTETimeType25: CVSMPTETimeType        = 1;
-pub const kCVSMPTETimeType30Drop: CVSMPTETimeType    = 2;
-pub const kCVSMPTETimeType30: CVSMPTETimeType        = 3;
-pub const kCVSMPTETimeType2997: CVSMPTETimeType      = 4;
-pub const kCVSMPTETimeType2997Drop: CVSMPTETimeType  = 5;
-pub const kCVSMPTETimeType60: CVSMPTETimeType        = 6;
-pub const kCVSMPTETimeType5994: CVSMPTETimeType      = 7;
-
-pub const kCVSMPTETimeValid: CVSMPTETimeFlags   = 1 << 0;
+pub const kCVSMPTETimeValid: CVSMPTETimeFlags = 1 << 0;
 pub const kCVSMPTETimeRunning: CVSMPTETimeFlags = 1 << 1;
 
 pub const kCVTimeIsIndefinite: CVTimeFlags = 1 << 0;
-
 
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -38,13 +35,12 @@ pub struct CVSMPTETime {
     pub frames: i16,
 }
 
-
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct CVTime {
     pub timeValue: i64,
     pub timeScale: i32,
-    pub flags: i32
+    pub flags: i32,
 }
 
 #[repr(C)]
@@ -61,21 +57,21 @@ pub struct CVTimeStamp {
     pub reserved: u64,
 }
 
-
-pub const kCVTimeStampVideoTimeValid: CVTimeStampFlags              = 1 << 0;
-pub const kCVTimeStampHostTimeValid: CVTimeStampFlags               = 1 << 1;
-pub const kCVTimeStampSMPTETimeValid: CVTimeStampFlags              = 1 << 2;
-pub const kCVTimeStampVideoRefreshPeriodValid: CVTimeStampFlags     = 1 << 3;
-pub const kCVTimeStampRateScalarValid: CVTimeStampFlags             = 1 << 4;
+pub const kCVTimeStampVideoTimeValid: CVTimeStampFlags = 1 << 0;
+pub const kCVTimeStampHostTimeValid: CVTimeStampFlags = 1 << 1;
+pub const kCVTimeStampSMPTETimeValid: CVTimeStampFlags = 1 << 2;
+pub const kCVTimeStampVideoRefreshPeriodValid: CVTimeStampFlags = 1 << 3;
+pub const kCVTimeStampRateScalarValid: CVTimeStampFlags = 1 << 4;
 
 // There are flags for each field to make it easier to detect interlaced vs progressive output
-pub const kCVTimeStampTopField: CVTimeStampFlags                    = 1 << 16;
-pub const kCVTimeStampBottomField: CVTimeStampFlags                 = 1 << 17;
+pub const kCVTimeStampTopField: CVTimeStampFlags = 1 << 16;
+pub const kCVTimeStampBottomField: CVTimeStampFlags = 1 << 17;
 
 // Some commonly used combinations of timestamp flags
-pub const kCVTimeStampVideoHostTimeValid: CVTimeStampFlags          = kCVTimeStampVideoTimeValid | kCVTimeStampHostTimeValid;
-pub const kCVTimeStampIsInterlaced: CVTimeStampFlags                = kCVTimeStampTopField | kCVTimeStampBottomField;
-
+pub const kCVTimeStampVideoHostTimeValid: CVTimeStampFlags =
+    kCVTimeStampVideoTimeValid | kCVTimeStampHostTimeValid;
+pub const kCVTimeStampIsInterlaced: CVTimeStampFlags =
+    kCVTimeStampTopField | kCVTimeStampBottomField;
 
 extern "C" {
     pub static kCVZeroTime: CVTime;

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,4 +1,4 @@
-use crate::libc::c_double;
+use libc::c_double;
 
 
 // https://developer.apple.com/documentation/corevideo/cvoptionflags?language=objc

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,4 @@
-use crate::core_foundation_sys::{
+use core_foundation_sys::{
     base::{ CFTypeRef, },
     string::CFStringRef,
     dictionary::CFDictionaryRef,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,20 +1,12 @@
-use core_foundation_sys::{
-    base::{ CFTypeRef, },
-    string::CFStringRef,
-    dictionary::CFDictionaryRef,
-};
-
-
+use core_foundation_sys::{base::CFTypeRef, dictionary::CFDictionaryRef, string::CFStringRef};
 
 #[derive(Debug, Copy, Clone)]
-pub enum __CVBuffer { }
+pub enum __CVBuffer {}
 pub type CVBufferRef = *mut __CVBuffer;
-
 
 pub type CVAttachmentMode = u32;
 pub const kCVAttachmentMode_ShouldNotPropagate: CVAttachmentMode = 0;
 pub const kCVAttachmentMode_ShouldPropagate: CVAttachmentMode = 1;
-
 
 extern "C" {
     pub static kCVBufferPropagatedAttachmentsKey: CFStringRef;
@@ -26,22 +18,28 @@ extern "C" {
 
     pub fn CVBufferRetain(buffer: CVBufferRef) -> CVBufferRef;
     pub fn CVBufferRelease(buffer: CVBufferRef);
-    pub fn CVBufferSetAttachment(buffer: CVBufferRef,
-                                 key: CFStringRef,
-                                 value: CFTypeRef,
-                                 attachmentMode: CVAttachmentMode);
-    pub fn CVBufferGetAttachment(buffer: CVBufferRef,
-                                 key: CFStringRef,
-                                 attachmentMode: *mut CVAttachmentMode) -> CFTypeRef;
-    pub fn CVBufferRemoveAttachment(buffer: CVBufferRef,
-                                    key: CFStringRef);
+    pub fn CVBufferSetAttachment(
+        buffer: CVBufferRef,
+        key: CFStringRef,
+        value: CFTypeRef,
+        attachmentMode: CVAttachmentMode,
+    );
+    pub fn CVBufferGetAttachment(
+        buffer: CVBufferRef,
+        key: CFStringRef,
+        attachmentMode: *mut CVAttachmentMode,
+    ) -> CFTypeRef;
+    pub fn CVBufferRemoveAttachment(buffer: CVBufferRef, key: CFStringRef);
     pub fn CVBufferRemoveAllAttachments(buffer: CVBufferRef);
-    pub fn CVBufferGetAttachments(buffer: CVBufferRef,
-                                  attachmentMode: CVAttachmentMode) -> CFDictionaryRef;
-    pub fn CVBufferSetAttachments(buffer: CVBufferRef,
-                                  theAttachments: CFDictionaryRef,
-                                  attachmentMode: CVAttachmentMode);
-    pub fn CVBufferPropagateAttachments(sourceBuffer: CVBufferRef,
-                                        destinationBuffer: CVBufferRef);
+    pub fn CVBufferGetAttachments(
+        buffer: CVBufferRef,
+        attachmentMode: CVAttachmentMode,
+    ) -> CFDictionaryRef;
+    pub fn CVBufferSetAttachments(
+        buffer: CVBufferRef,
+        theAttachments: CFDictionaryRef,
+        attachmentMode: CVAttachmentMode,
+    );
+    pub fn CVBufferPropagateAttachments(sourceBuffer: CVBufferRef, destinationBuffer: CVBufferRef);
 
 }

--- a/src/display_link.rs
+++ b/src/display_link.rs
@@ -1,8 +1,10 @@
+use core_foundation_sys::base::CFTypeID;
 use crate::{
-    core_foundation_sys::base::CFTypeID,
-    core_graphics::display::CGDirectDisplayID,
     CVReturn, CVTime,
 };
+
+// avoid depending on core-graphics
+pub type CGDirectDisplayID = u32;
 
 #[derive(Debug, Copy, Clone)]
 pub enum __CVDisplayLink { }

--- a/src/display_link.rs
+++ b/src/display_link.rs
@@ -1,18 +1,20 @@
+use crate::{CVReturn, CVTime};
 use core_foundation_sys::base::CFTypeID;
-use crate::{
-    CVReturn, CVTime,
-};
 
 // avoid depending on core-graphics
 pub type CGDirectDisplayID = u32;
 
 #[derive(Debug, Copy, Clone)]
-pub enum __CVDisplayLink { }
+pub enum __CVDisplayLink {}
 pub type CVDisplayLinkRef = *mut __CVDisplayLink;
 
 extern "C" {
     pub fn CVDisplayLinkGetTypeID() -> CFTypeID;
-    pub fn CVDisplayLinkCreateWithCGDisplay(displayID: CGDirectDisplayID, displayLinkOut: *mut CVDisplayLinkRef) -> CVReturn;
-    pub fn CVDisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink: CVDisplayLinkRef) -> CVTime;
+    pub fn CVDisplayLinkCreateWithCGDisplay(
+        displayID: CGDirectDisplayID,
+        displayLinkOut: *mut CVDisplayLinkRef,
+    ) -> CVReturn;
+    pub fn CVDisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink: CVDisplayLinkRef)
+        -> CVTime;
     pub fn CVDisplayLinkRelease(displayLink: CVDisplayLinkRef);
 }

--- a/src/host_time.rs
+++ b/src/host_time.rs
@@ -19,7 +19,6 @@ extern "C" {
     pub fn CVGetHostClockMinimumTimeDelta() -> u32;
 }
 
-
 #[test]
 fn test_get_curr_time() {
     unsafe {

--- a/src/host_time.rs
+++ b/src/host_time.rs
@@ -1,4 +1,4 @@
-use crate::libc::c_double;
+use libc::c_double;
 
 extern "C" {
     /// @function   CVGetCurrentHostTime

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,6 @@
 
 #[macro_use]
 extern crate cfg_if;
-extern crate libc;
-extern crate objc;
-extern crate core_foundation_sys;
-
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[link(name = "CoreVideo", kind = "framework")]
@@ -42,8 +38,6 @@ pub use self::pixel_format_description::*;
 
 cfg_if! {
     if #[cfg(feature = "metal")] {
-        extern crate metal;
-
         pub mod metal_texture;
         pub mod metal_texture_cache;
 
@@ -54,8 +48,6 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(feature = "display_link")] {
-        extern crate core_graphics;
-
         pub mod host_time;
         pub mod display_link;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,7 @@ extern crate cfg_if;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[link(name = "CoreVideo", kind = "framework")]
-extern "C" { }
-
+extern "C" {}
 
 pub(crate) type OSType = u32;
 pub(crate) type GLenum = libc::c_uint;
@@ -19,22 +18,21 @@ pub(crate) type GLsizei = libc::c_int;
 pub(crate) type GLint = libc::c_int;
 pub(crate) type GLuint = libc::c_uint;
 
-
 pub mod base;
 pub mod buffer;
-pub mod return_;
 pub mod image_buffer;
 pub mod pixel_buffer;
 pub mod pixel_buffer_pool;
 pub mod pixel_format_description;
+pub mod return_;
 
 pub use self::base::*;
 pub use self::buffer::*;
-pub use self::return_::*;
 pub use self::image_buffer::*;
 pub use self::pixel_buffer::*;
 pub use self::pixel_buffer_pool::*;
 pub use self::pixel_format_description::*;
+pub use self::return_::*;
 
 cfg_if! {
     if #[cfg(feature = "metal")] {
@@ -78,11 +76,8 @@ cfg_if! {
     }
 }
 
-
 pub mod open_gl_es_texture;
 pub mod open_gl_es_texture_cache;
 
 pub use self::open_gl_es_texture::*;
 pub use self::open_gl_es_texture_cache::*;
-
-

--- a/src/metal_texture.rs
+++ b/src/metal_texture.rs
@@ -1,5 +1,5 @@
-use crate::metal::Texture;
-use crate::core_foundation_sys::{
+use metal::Texture;
+use core_foundation_sys::{
     base::{ Boolean, CFTypeID, },
     string::CFStringRef,
 };

--- a/src/metal_texture.rs
+++ b/src/metal_texture.rs
@@ -1,19 +1,15 @@
-use metal::Texture;
 use core_foundation_sys::{
-    base::{ Boolean, CFTypeID, },
+    base::{Boolean, CFTypeID},
     string::CFStringRef,
 };
+use metal::Texture;
 
-use crate::{
-    image_buffer::CVImageBufferRef,
-};
-
+use crate::image_buffer::CVImageBufferRef;
 
 pub type CVMetalTextureRef = CVImageBufferRef;
 
 extern "C" {
     pub static kCVMetalTextureUsage: CFStringRef;
-
 
     pub fn CVMetalTextureGetTypeID() -> CFTypeID;
     pub fn CVMetalTextureGetTexture(image: CVMetalTextureRef) -> Texture;

--- a/src/metal_texture_cache.rs
+++ b/src/metal_texture_cache.rs
@@ -1,5 +1,5 @@
-use crate::libc::size_t;
-use crate::core_foundation_sys::{
+use libc::size_t;
+use core_foundation_sys::{
     base::{CFAllocatorRef, CFTypeID, CFTypeRef},
     dictionary::CFDictionaryRef,
     string::CFStringRef,

--- a/src/metal_texture_cache.rs
+++ b/src/metal_texture_cache.rs
@@ -1,22 +1,18 @@
-use libc::size_t;
+use crate::{
+    base::CVOptionFlags, image_buffer::CVImageBufferRef, metal_texture::CVMetalTextureRef,
+    return_::CVReturn,
+};
 use core_foundation_sys::{
     base::{CFAllocatorRef, CFTypeID, CFTypeRef},
     dictionary::CFDictionaryRef,
     string::CFStringRef,
 };
-use crate::{
-    base::CVOptionFlags,
-    image_buffer::CVImageBufferRef, 
-    metal_texture::CVMetalTextureRef,
-    return_::CVReturn,
-};
-
+use libc::size_t;
 
 pub type CVMetalTextureCacheRef = CFTypeRef;
 
 extern "C" {
     pub static kCVMetalTextureCacheMaximumTextureAgeKey: CFStringRef;
-
 
     pub fn CVMetalTextureCacheGetTypeID() -> CFTypeID;
     pub fn CVMetalTextureCacheCreate(
@@ -37,6 +33,5 @@ extern "C" {
         planeIndex: size_t,
         textureOut: *mut CVMetalTextureRef,
     ) -> CVReturn;
-    pub fn CVMetalTextureCacheFlush(textureCache: CVMetalTextureCacheRef,
-                                    options: CVOptionFlags);
+    pub fn CVMetalTextureCacheFlush(textureCache: CVMetalTextureCacheRef, options: CVOptionFlags);
 }

--- a/src/open_gl_es_texture.rs
+++ b/src/open_gl_es_texture.rs
@@ -1,4 +1,4 @@
-use crate::core_foundation_sys::base::{ Boolean, CFTypeID };
+use core_foundation_sys::base::{ Boolean, CFTypeID };
 
 use crate::{
     GLenum, GLuint,

--- a/src/open_gl_es_texture.rs
+++ b/src/open_gl_es_texture.rs
@@ -1,10 +1,6 @@
-use core_foundation_sys::base::{ Boolean, CFTypeID };
+use core_foundation_sys::base::{Boolean, CFTypeID};
 
-use crate::{
-    GLenum, GLuint,
-    image_buffer::CVImageBufferRef,
-};
-
+use crate::{image_buffer::CVImageBufferRef, GLenum, GLuint};
 
 pub type CVOpenGLESTextureRef = CVImageBufferRef;
 
@@ -17,10 +13,10 @@ extern "C" {
 
     pub fn CVOpenGLESTextureIsFlipped(image: CVOpenGLESTextureRef) -> Boolean;
 
-//pub fn CVOpenGLESTextureGetCleanTexCoords( image:CVOpenGLESTextureRef  ,
-//    GLfloat lowerLeft[ 2],
-//    GLfloat lowerRight[ 2],
-//    GLfloat upperRight[ 2],
-//    GLfloat upperLeft[ 2] );
+    //pub fn CVOpenGLESTextureGetCleanTexCoords( image:CVOpenGLESTextureRef  ,
+    //    GLfloat lowerLeft[ 2],
+    //    GLfloat lowerRight[ 2],
+    //    GLfloat upperRight[ 2],
+    //    GLfloat upperLeft[ 2] );
 
 }

--- a/src/open_gl_es_texture_cache.rs
+++ b/src/open_gl_es_texture_cache.rs
@@ -1,17 +1,14 @@
-use libc::size_t;
-use objc::runtime::Object;
 use core_foundation_sys::{
-    base::{ CFAllocatorRef, CFTypeRef },
+    base::{CFAllocatorRef, CFTypeRef},
     dictionary::CFDictionaryRef,
 };
+use libc::size_t;
+use objc::runtime::Object;
 
 use crate::{
+    image_buffer::CVImageBufferRef, open_gl_es_texture::CVOpenGLESTextureRef, return_::CVReturn,
     GLenum, GLint, GLsizei,
-    return_::CVReturn,
-    image_buffer::CVImageBufferRef, 
-    open_gl_es_texture::CVOpenGLESTextureRef, 
 };
-
 
 pub type CVOpenGLESTextureCacheRef = CFTypeRef;
 pub type CVEAGLContext = *mut Object;

--- a/src/open_gl_es_texture_cache.rs
+++ b/src/open_gl_es_texture_cache.rs
@@ -1,6 +1,6 @@
-use crate::libc::size_t;
-use crate::objc::runtime::Object;
-use crate::core_foundation_sys::{
+use libc::size_t;
+use objc::runtime::Object;
+use core_foundation_sys::{
     base::{ CFAllocatorRef, CFTypeRef },
     dictionary::CFDictionaryRef,
 };

--- a/src/opengl_buffer.rs
+++ b/src/opengl_buffer.rs
@@ -1,15 +1,10 @@
-use libc::size_t;
+use crate::{image_buffer::CVImageBufferRef, return_::CVReturn, GLenum, GLint};
 use core_foundation_sys::{
-    base::{ CFAllocatorRef, CFTypeID, },
+    base::{CFAllocatorRef, CFTypeID},
     dictionary::CFDictionaryRef,
     string::CFStringRef,
 };
-use crate::{
-    GLenum, GLint,
-    return_::CVReturn,
-    image_buffer::CVImageBufferRef,
-};
-
+use libc::size_t;
 
 pub type CVOpenGLBufferRef = CVImageBufferRef;
 // https://developer.apple.com/documentation/appkit/nsopenglcontext/1436158-cglcontextobj?language=objc
@@ -24,19 +19,22 @@ extern "C" {
     pub static kCVOpenGLBufferInternalFormat: CFStringRef;
     pub static kCVOpenGLBufferMaximumMipmapLevel: CFStringRef;
 
-
     pub fn CVOpenGLBufferGetTypeID() -> CFTypeID;
     pub fn CVOpenGLBufferRetain(buffer: CVOpenGLBufferRef) -> CVOpenGLBufferRef;
     pub fn CVOpenGLBufferRelease(buffer: CVOpenGLBufferRef);
-    pub fn CVOpenGLBufferCreate(allocator: CFAllocatorRef,
-                                width: size_t,
-                                height: size_t,
-                                attributes: CFDictionaryRef,
-                                bufferOut: *mut CVOpenGLBufferRef) -> CVReturn;
+    pub fn CVOpenGLBufferCreate(
+        allocator: CFAllocatorRef,
+        width: size_t,
+        height: size_t,
+        attributes: CFDictionaryRef,
+        bufferOut: *mut CVOpenGLBufferRef,
+    ) -> CVReturn;
     pub fn CVOpenGLBufferGetAttributes(openGLBuffer: CVOpenGLBufferRef) -> CFDictionaryRef;
-    pub fn CVOpenGLBufferAttach(openGLBuffer: CVOpenGLBufferRef,
-                                cglContext: CGLContextObj,
-                                face: GLenum,
-                                level: GLint,
-                                screen: GLint) -> CVReturn;
+    pub fn CVOpenGLBufferAttach(
+        openGLBuffer: CVOpenGLBufferRef,
+        cglContext: CGLContextObj,
+        face: GLenum,
+        level: GLint,
+        screen: GLint,
+    ) -> CVReturn;
 }

--- a/src/opengl_buffer.rs
+++ b/src/opengl_buffer.rs
@@ -1,5 +1,5 @@
-use crate::libc::size_t;
-use crate::core_foundation_sys::{
+use libc::size_t;
+use core_foundation_sys::{
     base::{ CFAllocatorRef, CFTypeID, },
     dictionary::CFDictionaryRef,
     string::CFStringRef,

--- a/src/opengl_buffer_pool.rs
+++ b/src/opengl_buffer_pool.rs
@@ -1,4 +1,4 @@
-use crate::core_foundation_sys::{
+use core_foundation_sys::{
     base::{ CFAllocatorRef, CFTypeID, },
     dictionary::CFDictionaryRef,
     string::CFStringRef,

--- a/src/opengl_buffer_pool.rs
+++ b/src/opengl_buffer_pool.rs
@@ -1,32 +1,32 @@
 use core_foundation_sys::{
-    base::{ CFAllocatorRef, CFTypeID, },
+    base::{CFAllocatorRef, CFTypeID},
     dictionary::CFDictionaryRef,
     string::CFStringRef,
 };
 
-use crate::{
-    return_::CVReturn,
-    image_buffer::CVImageBufferRef,
-    opengl_buffer::{ CVOpenGLBufferRef, },
-};
-
+use crate::{image_buffer::CVImageBufferRef, opengl_buffer::CVOpenGLBufferRef, return_::CVReturn};
 
 pub type CVOpenGLBufferPoolRef = CVImageBufferRef;
-
 
 extern "C" {
     pub static kCVOpenGLBufferPoolMinimumBufferCountKey: CFStringRef;
     pub static kCVOpenGLBufferPoolMaximumBufferAgeKey: CFStringRef;
 
     pub fn CVOpenGLBufferPoolGetTypeID() -> CFTypeID;
-    pub fn CVOpenGLBufferPoolRetain(openGLBufferPool: CVOpenGLBufferPoolRef) -> CVOpenGLBufferPoolRef;
+    pub fn CVOpenGLBufferPoolRetain(
+        openGLBufferPool: CVOpenGLBufferPoolRef,
+    ) -> CVOpenGLBufferPoolRef;
     pub fn CVOpenGLBufferPoolRelease(openGLBufferPool: CVOpenGLBufferPoolRef);
-    pub fn CVOpenGLBufferPoolCreate(allocator: CFAllocatorRef,
-                                    poolAttributes: CFDictionaryRef,
-                                    openGLBufferAttributes: CFDictionaryRef,
-                                    poolOut: *mut CVOpenGLBufferPoolRef) -> CVReturn;
+    pub fn CVOpenGLBufferPoolCreate(
+        allocator: CFAllocatorRef,
+        poolAttributes: CFDictionaryRef,
+        openGLBufferAttributes: CFDictionaryRef,
+        poolOut: *mut CVOpenGLBufferPoolRef,
+    ) -> CVReturn;
     pub fn CVOpenGLBufferPoolGetAttributes(pool: CVOpenGLBufferPoolRef) -> CFDictionaryRef;
-    pub fn CVOpenGLBufferPoolCreateOpenGLBuffer(allocator: CFAllocatorRef,
-                                                openGLBufferPool: CVOpenGLBufferPoolRef,
-                                                openGLBufferOut: *mut CVOpenGLBufferRef) -> CVReturn;
+    pub fn CVOpenGLBufferPoolCreateOpenGLBuffer(
+        allocator: CFAllocatorRef,
+        openGLBufferPool: CVOpenGLBufferPoolRef,
+        openGLBufferOut: *mut CVOpenGLBufferRef,
+    ) -> CVReturn;
 }

--- a/src/opengl_texture.rs
+++ b/src/opengl_texture.rs
@@ -1,4 +1,4 @@
-use crate::core_foundation_sys::{
+use core_foundation_sys::{
     base::{ Boolean, CFTypeID, },
 };
 

--- a/src/opengl_texture.rs
+++ b/src/opengl_texture.rs
@@ -1,15 +1,8 @@
-use core_foundation_sys::{
-    base::{ Boolean, CFTypeID, },
-};
+use core_foundation_sys::base::{Boolean, CFTypeID};
 
-use crate::{
-    GLenum, GLuint,
-    image_buffer::CVImageBufferRef,
-};
-
+use crate::{image_buffer::CVImageBufferRef, GLenum, GLuint};
 
 pub type CVOpenGLTextureRef = CVImageBufferRef;
-
 
 extern "C" {
     pub fn CVOpenGLTextureGetTypeID() -> CFTypeID;
@@ -20,7 +13,7 @@ extern "C" {
     pub fn CVOpenGLTextureIsFlipped(image: CVOpenGLTextureRef) -> Boolean;
     // CV_EXPORT void CVOpenGLTextureGetCleanTexCoords( CVOpenGLTextureRef CV_NONNULL image,
     //                      GLfloat lowerLeft[2],
-    //                      GLfloat lowerRight[2], 
+    //                      GLfloat lowerRight[2],
     //                      GLfloat upperRight[2],
     //                      GLfloat upperLeft[2] ) AVAILABLE_MAC_OS_X_VERSION_10_4_AND_LATER;
 }

--- a/src/opengl_texture_cache.rs
+++ b/src/opengl_texture_cache.rs
@@ -1,4 +1,4 @@
-use crate::core_foundation_sys::{
+use core_foundation_sys::{
     base::{ CFAllocatorRef, CFTypeID, },
     dictionary::CFDictionaryRef,
     string::CFStringRef,

--- a/src/opengl_texture_cache.rs
+++ b/src/opengl_texture_cache.rs
@@ -1,21 +1,18 @@
 use core_foundation_sys::{
-    base::{ CFAllocatorRef, CFTypeID, },
+    base::{CFAllocatorRef, CFTypeID},
     dictionary::CFDictionaryRef,
     string::CFStringRef,
 };
 
 use crate::{
     base::CVOptionFlags,
-    return_::CVReturn,
     image_buffer::CVImageBufferRef,
-    opengl_buffer::{ CGLContextObj, CGLPixelFormatObj, },
+    opengl_buffer::{CGLContextObj, CGLPixelFormatObj},
     opengl_texture::CVOpenGLTextureRef,
-    
+    return_::CVReturn,
 };
 
-
 pub type CVOpenGLTextureCacheRef = CVImageBufferRef;
-
 
 extern "C" {
     pub static kCVOpenGLTextureCacheChromaSamplingModeKey: CFStringRef;
@@ -24,19 +21,24 @@ extern "C" {
     pub static kCVOpenGLTextureCacheChromaSamplingModeBestPerformance: CFStringRef;
 
     pub fn CVOpenGLTextureCacheGetTypeID() -> CFTypeID;
-    pub fn CVOpenGLTextureCacheRetain(textureCache: CVOpenGLTextureCacheRef) -> CVOpenGLTextureCacheRef;
+    pub fn CVOpenGLTextureCacheRetain(
+        textureCache: CVOpenGLTextureCacheRef,
+    ) -> CVOpenGLTextureCacheRef;
     pub fn CVOpenGLTextureCacheRelease(textureCache: CVOpenGLTextureCacheRef);
-    pub fn CVOpenGLTextureCacheCreate(allocator: CFAllocatorRef,
-                                      cacheAttributes: CFDictionaryRef,
-                                      cglContext: CGLContextObj,
-                                      cglPixelFormat: CGLPixelFormatObj,
-                                      textureAttributes: CFDictionaryRef,
-                                      cacheOut: *mut CVOpenGLTextureCacheRef) -> CVReturn;
-    pub fn CVOpenGLTextureCacheCreateTextureFromImage(allocator: CFAllocatorRef,
-                                                      textureCache: CVOpenGLTextureCacheRef,
-                                                      sourceImage: CVImageBufferRef,
-                                                      attributes: CFDictionaryRef,
-                                                      textureOut: *mut CVOpenGLTextureRef) -> CVReturn;
-    pub fn CVOpenGLTextureCacheFlush(textureCache: CVOpenGLTextureCacheRef,
-                                     options: CVOptionFlags);
+    pub fn CVOpenGLTextureCacheCreate(
+        allocator: CFAllocatorRef,
+        cacheAttributes: CFDictionaryRef,
+        cglContext: CGLContextObj,
+        cglPixelFormat: CGLPixelFormatObj,
+        textureAttributes: CFDictionaryRef,
+        cacheOut: *mut CVOpenGLTextureCacheRef,
+    ) -> CVReturn;
+    pub fn CVOpenGLTextureCacheCreateTextureFromImage(
+        allocator: CFAllocatorRef,
+        textureCache: CVOpenGLTextureCacheRef,
+        sourceImage: CVImageBufferRef,
+        attributes: CFDictionaryRef,
+        textureOut: *mut CVOpenGLTextureRef,
+    ) -> CVReturn;
+    pub fn CVOpenGLTextureCacheFlush(textureCache: CVOpenGLTextureCacheRef, options: CVOptionFlags);
 }

--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -1,5 +1,5 @@
-use crate::libc::{ c_void, size_t, };
-use crate::core_foundation_sys::{
+use libc::{ c_void, size_t, };
+use core_foundation_sys::{
     base::{ Boolean, CFAllocatorRef, CFTypeID },
     dictionary::CFDictionaryRef,
     array::CFArrayRef,

--- a/src/pixel_buffer.rs
+++ b/src/pixel_buffer.rs
@@ -1,103 +1,94 @@
-use libc::{ c_void, size_t, };
 use core_foundation_sys::{
-    base::{ Boolean, CFAllocatorRef, CFTypeID },
-    dictionary::CFDictionaryRef,
     array::CFArrayRef,
+    base::{Boolean, CFAllocatorRef, CFTypeID},
+    dictionary::CFDictionaryRef,
     string::CFStringRef,
 };
+use libc::{c_void, size_t};
 
-use crate::{
-    OSType,
-    base::CVOptionFlags,
-    image_buffer::CVImageBufferRef,
-    return_::CVReturn,
-};
-
+use crate::{base::CVOptionFlags, image_buffer::CVImageBufferRef, return_::CVReturn, OSType};
 
 const fn as_u32_be(array: &[u8; 4]) -> u32 {
-    ((array[0] as u32) << 24) +
-    ((array[1] as u32) << 16) +
-    ((array[2] as u32) <<  8) +
-    ((array[3] as u32) <<  0)
+    ((array[0] as u32) << 24)
+        + ((array[1] as u32) << 16)
+        + ((array[2] as u32) << 8)
+        + ((array[3] as u32) << 0)
 }
-
 
 pub type CVPixelBufferLockFlags = u64;
 pub type CVPixelBufferRef = CVImageBufferRef;
 
-
-pub const kCVPixelFormatType_1Monochrome: OSType    = 0x00000001; /* 1 bit indexed */
-pub const kCVPixelFormatType_2Indexed: OSType       = 0x00000002; /* 2 bit indexed */
-pub const kCVPixelFormatType_4Indexed: OSType       = 0x00000004; /* 4 bit indexed */
-pub const kCVPixelFormatType_8Indexed: OSType       = 0x00000008; /* 8 bit indexed */
+pub const kCVPixelFormatType_1Monochrome: OSType = 0x00000001; /* 1 bit indexed */
+pub const kCVPixelFormatType_2Indexed: OSType = 0x00000002; /* 2 bit indexed */
+pub const kCVPixelFormatType_4Indexed: OSType = 0x00000004; /* 4 bit indexed */
+pub const kCVPixelFormatType_8Indexed: OSType = 0x00000008; /* 8 bit indexed */
 pub const kCVPixelFormatType_1IndexedGray_WhiteIsZero: OSType = 0x00000021; /* 1 bit indexed gray, white is zero */
 pub const kCVPixelFormatType_2IndexedGray_WhiteIsZero: OSType = 0x00000022; /* 2 bit indexed gray, white is zero */
 pub const kCVPixelFormatType_4IndexedGray_WhiteIsZero: OSType = 0x00000024; /* 4 bit indexed gray, white is zero */
 pub const kCVPixelFormatType_8IndexedGray_WhiteIsZero: OSType = 0x00000028; /* 8 bit indexed gray, white is zero */
-pub const kCVPixelFormatType_16BE555: OSType        = 0x00000010; /* 16 bit BE RGB 555 */
-pub const kCVPixelFormatType_16LE555: OSType        = as_u32_be(b"L555");     /* 16 bit LE RGB 555 */
-pub const kCVPixelFormatType_16LE5551: OSType       = as_u32_be(b"5551");     /* 16 bit LE RGB 5551 */
-pub const kCVPixelFormatType_16BE565: OSType        = as_u32_be(b"B565");     /* 16 bit BE RGB 565 */
-pub const kCVPixelFormatType_16LE565: OSType        = as_u32_be(b"L565");     /* 16 bit LE RGB 565 */
-pub const kCVPixelFormatType_24RGB: OSType          = 0x00000018; /* 24 bit RGB */
-pub const kCVPixelFormatType_24BGR: OSType          = as_u32_be(b"24BG");     /* 24 bit BGR */
-pub const kCVPixelFormatType_32ARGB: OSType         = 0x00000020; /* 32 bit ARGB */
-pub const kCVPixelFormatType_32BGRA: OSType         = as_u32_be(b"BGRA");     /* 32 bit BGRA */
-pub const kCVPixelFormatType_32ABGR: OSType         = as_u32_be(b"ABGR");     /* 32 bit ABGR */
-pub const kCVPixelFormatType_32RGBA: OSType         = as_u32_be(b"RGBA");     /* 32 bit RGBA */
-pub const kCVPixelFormatType_64ARGB: OSType         = as_u32_be(b"b64a");     /* 64 bit ARGB, 16-bit big-endian samples */
-pub const kCVPixelFormatType_48RGB: OSType          = as_u32_be(b"b48r");     /* 48 bit RGB, 16-bit big-endian samples */
-pub const kCVPixelFormatType_32AlphaGray: OSType    = as_u32_be(b"b32a");     /* 32 bit AlphaGray, 16-bit big-endian samples, black is zero */
-pub const kCVPixelFormatType_16Gray: OSType         = as_u32_be(b"b16g");     /* 16 bit Grayscale, 16-bit big-endian samples, black is zero */
-pub const kCVPixelFormatType_30RGB: OSType          = as_u32_be(b"R10k");     /* 30 bit RGB, 10-bit big-endian samples, 2 unused padding bits (at least significant end). */
-pub const kCVPixelFormatType_422YpCbCr8: OSType     = as_u32_be(b"2vuy");     /* Component Y'CbCr 8-bit 4:2:2, ordered Cb Y'0 Cr Y'1 */
-pub const kCVPixelFormatType_4444YpCbCrA8: OSType   = as_u32_be(b"v408");     /* Component Y'CbCrA 8-bit 4:4:4:4, ordered Cb Y' Cr A */
-pub const kCVPixelFormatType_4444YpCbCrA8R: OSType  = as_u32_be(b"r408");     /* Component Y'CbCrA 8-bit 4:4:4:4, rendering format. full range alpha, zero biased YUV, ordered A Y' Cb Cr */
-pub const kCVPixelFormatType_4444AYpCbCr8: OSType   = as_u32_be(b"y408");     /* Component Y'CbCrA 8-bit 4:4:4:4, ordered A Y' Cb Cr, full range alpha, video range Y'CbCr. */
-pub const kCVPixelFormatType_4444AYpCbCr16: OSType  = as_u32_be(b"y416");     /* Component Y'CbCrA 16-bit 4:4:4:4, ordered A Y' Cb Cr, full range alpha, video range Y'CbCr, 16-bit little-endian samples. */
-pub const kCVPixelFormatType_444YpCbCr8: OSType     = as_u32_be(b"v308");     /* Component Y'CbCr 8-bit 4:4:4 */
-pub const kCVPixelFormatType_422YpCbCr16: OSType    = as_u32_be(b"v216");     /* Component Y'CbCr 10,12,14,16-bit 4:2:2 */
-pub const kCVPixelFormatType_422YpCbCr10: OSType    = as_u32_be(b"v210");     /* Component Y'CbCr 10-bit 4:2:2 */
-pub const kCVPixelFormatType_444YpCbCr10: OSType    = as_u32_be(b"v410");     /* Component Y'CbCr 10-bit 4:4:4 */
-pub const kCVPixelFormatType_420YpCbCr8Planar: OSType = as_u32_be(b"y420");   /* Planar Component Y'CbCr 8-bit 4:2:0.  baseAddr points to a big-endian CVPlanarPixelBufferInfo_YCbCrPlanar struct */
-pub const kCVPixelFormatType_420YpCbCr8PlanarFullRange: OSType    = as_u32_be(b"f420");   /* Planar Component Y'CbCr 8-bit 4:2:0, full range.  baseAddr points to a big-endian CVPlanarPixelBufferInfo_YCbCrPlanar struct */
+pub const kCVPixelFormatType_16BE555: OSType = 0x00000010; /* 16 bit BE RGB 555 */
+pub const kCVPixelFormatType_16LE555: OSType = as_u32_be(b"L555"); /* 16 bit LE RGB 555 */
+pub const kCVPixelFormatType_16LE5551: OSType = as_u32_be(b"5551"); /* 16 bit LE RGB 5551 */
+pub const kCVPixelFormatType_16BE565: OSType = as_u32_be(b"B565"); /* 16 bit BE RGB 565 */
+pub const kCVPixelFormatType_16LE565: OSType = as_u32_be(b"L565"); /* 16 bit LE RGB 565 */
+pub const kCVPixelFormatType_24RGB: OSType = 0x00000018; /* 24 bit RGB */
+pub const kCVPixelFormatType_24BGR: OSType = as_u32_be(b"24BG"); /* 24 bit BGR */
+pub const kCVPixelFormatType_32ARGB: OSType = 0x00000020; /* 32 bit ARGB */
+pub const kCVPixelFormatType_32BGRA: OSType = as_u32_be(b"BGRA"); /* 32 bit BGRA */
+pub const kCVPixelFormatType_32ABGR: OSType = as_u32_be(b"ABGR"); /* 32 bit ABGR */
+pub const kCVPixelFormatType_32RGBA: OSType = as_u32_be(b"RGBA"); /* 32 bit RGBA */
+pub const kCVPixelFormatType_64ARGB: OSType = as_u32_be(b"b64a"); /* 64 bit ARGB, 16-bit big-endian samples */
+pub const kCVPixelFormatType_48RGB: OSType = as_u32_be(b"b48r"); /* 48 bit RGB, 16-bit big-endian samples */
+pub const kCVPixelFormatType_32AlphaGray: OSType = as_u32_be(b"b32a"); /* 32 bit AlphaGray, 16-bit big-endian samples, black is zero */
+pub const kCVPixelFormatType_16Gray: OSType = as_u32_be(b"b16g"); /* 16 bit Grayscale, 16-bit big-endian samples, black is zero */
+pub const kCVPixelFormatType_30RGB: OSType = as_u32_be(b"R10k"); /* 30 bit RGB, 10-bit big-endian samples, 2 unused padding bits (at least significant end). */
+pub const kCVPixelFormatType_422YpCbCr8: OSType = as_u32_be(b"2vuy"); /* Component Y'CbCr 8-bit 4:2:2, ordered Cb Y'0 Cr Y'1 */
+pub const kCVPixelFormatType_4444YpCbCrA8: OSType = as_u32_be(b"v408"); /* Component Y'CbCrA 8-bit 4:4:4:4, ordered Cb Y' Cr A */
+pub const kCVPixelFormatType_4444YpCbCrA8R: OSType = as_u32_be(b"r408"); /* Component Y'CbCrA 8-bit 4:4:4:4, rendering format. full range alpha, zero biased YUV, ordered A Y' Cb Cr */
+pub const kCVPixelFormatType_4444AYpCbCr8: OSType = as_u32_be(b"y408"); /* Component Y'CbCrA 8-bit 4:4:4:4, ordered A Y' Cb Cr, full range alpha, video range Y'CbCr. */
+pub const kCVPixelFormatType_4444AYpCbCr16: OSType = as_u32_be(b"y416"); /* Component Y'CbCrA 16-bit 4:4:4:4, ordered A Y' Cb Cr, full range alpha, video range Y'CbCr, 16-bit little-endian samples. */
+pub const kCVPixelFormatType_444YpCbCr8: OSType = as_u32_be(b"v308"); /* Component Y'CbCr 8-bit 4:4:4 */
+pub const kCVPixelFormatType_422YpCbCr16: OSType = as_u32_be(b"v216"); /* Component Y'CbCr 10,12,14,16-bit 4:2:2 */
+pub const kCVPixelFormatType_422YpCbCr10: OSType = as_u32_be(b"v210"); /* Component Y'CbCr 10-bit 4:2:2 */
+pub const kCVPixelFormatType_444YpCbCr10: OSType = as_u32_be(b"v410"); /* Component Y'CbCr 10-bit 4:4:4 */
+pub const kCVPixelFormatType_420YpCbCr8Planar: OSType = as_u32_be(b"y420"); /* Planar Component Y'CbCr 8-bit 4:2:0.  baseAddr points to a big-endian CVPlanarPixelBufferInfo_YCbCrPlanar struct */
+pub const kCVPixelFormatType_420YpCbCr8PlanarFullRange: OSType = as_u32_be(b"f420"); /* Planar Component Y'CbCr 8-bit 4:2:0, full range.  baseAddr points to a big-endian CVPlanarPixelBufferInfo_YCbCrPlanar struct */
 pub const kCVPixelFormatType_422YpCbCr_4A_8BiPlanar: OSType = as_u32_be(b"a2vy"); /* First plane: Video-range Component Y'CbCr 8-bit 4:2:2, ordered Cb Y'0 Cr Y'1; second plane: alpha 8-bit 0-255 */
 pub const kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange: OSType = as_u32_be(b"420v"); /* Bi-Planar Component Y'CbCr 8-bit 4:2:0, video-range (luma=[16,235] chroma=[16,240]).  baseAddr points to a big-endian CVPlanarPixelBufferInfo_YCbCrBiPlanar struct */
-pub const kCVPixelFormatType_420YpCbCr8BiPlanarFullRange: OSType  = as_u32_be(b"420f"); /* Bi-Planar Component Y'CbCr 8-bit 4:2:0, full-range (luma=[0,255] chroma=[1,255]).  baseAddr points to a big-endian CVPlanarPixelBufferInfo_YCbCrBiPlanar struct */ 
-pub const kCVPixelFormatType_422YpCbCr8_yuvs: OSType = as_u32_be(b"yuvs");     /* Component Y'CbCr 8-bit 4:2:2, ordered Y'0 Cb Y'1 Cr */
+pub const kCVPixelFormatType_420YpCbCr8BiPlanarFullRange: OSType = as_u32_be(b"420f"); /* Bi-Planar Component Y'CbCr 8-bit 4:2:0, full-range (luma=[0,255] chroma=[1,255]).  baseAddr points to a big-endian CVPlanarPixelBufferInfo_YCbCrBiPlanar struct */
+pub const kCVPixelFormatType_422YpCbCr8_yuvs: OSType = as_u32_be(b"yuvs"); /* Component Y'CbCr 8-bit 4:2:2, ordered Y'0 Cb Y'1 Cr */
 pub const kCVPixelFormatType_422YpCbCr8FullRange: OSType = as_u32_be(b"yuvf"); /* Component Y'CbCr 8-bit 4:2:2, full range, ordered Y'0 Cb Y'1 Cr */
-pub const kCVPixelFormatType_OneComponent8: OSType  = as_u32_be(b"L008");     /* 8 bit one component, black is zero */
-pub const kCVPixelFormatType_TwoComponent8: OSType  = as_u32_be(b"2C08");     /* 8 bit two component, black is zero */
+pub const kCVPixelFormatType_OneComponent8: OSType = as_u32_be(b"L008"); /* 8 bit one component, black is zero */
+pub const kCVPixelFormatType_TwoComponent8: OSType = as_u32_be(b"2C08"); /* 8 bit two component, black is zero */
 pub const kCVPixelFormatType_30RGBLEPackedWideGamut: OSType = as_u32_be(b"w30r"); /* little-endian RGB101010, 2 MSB are zero, wide-gamut (384-895) */
-pub const kCVPixelFormatType_ARGB2101010LEPacked: OSType = as_u32_be(b"l10r");     /* little-endian ARGB2101010 full-range ARGB */
-pub const kCVPixelFormatType_OneComponent16Half: OSType  = as_u32_be(b"L00h");     /* 16 bit one component IEEE half-precision float, 16-bit little-endian samples */
-pub const kCVPixelFormatType_OneComponent32Float: OSType = as_u32_be(b"L00f");     /* 32 bit one component IEEE float, 32-bit little-endian samples */
-pub const kCVPixelFormatType_TwoComponent16Half: OSType  = as_u32_be(b"2C0h");     /* 16 bit two component IEEE half-precision float, 16-bit little-endian samples */
-pub const kCVPixelFormatType_TwoComponent32Float: OSType = as_u32_be(b"2C0f");     /* 32 bit two component IEEE float, 32-bit little-endian samples */
-pub const kCVPixelFormatType_64RGBAHalf: OSType          = as_u32_be(b"RGhA");     /* 64 bit RGBA IEEE half-precision float, 16-bit little-endian samples */
-pub const kCVPixelFormatType_128RGBAFloat: OSType        = as_u32_be(b"RGfA");     /* 128 bit RGBA IEEE float, 32-bit little-endian samples */
-pub const kCVPixelFormatType_14Bayer_GRBG: OSType        = as_u32_be(b"grb4");     /* Bayer 14-bit Little-Endian, packed in 16-bits, ordered G R G R... alternating with B G B G... */
-pub const kCVPixelFormatType_14Bayer_RGGB: OSType        = as_u32_be(b"rgg4");     /* Bayer 14-bit Little-Endian, packed in 16-bits, ordered R G R G... alternating with G B G B... */
-pub const kCVPixelFormatType_14Bayer_BGGR: OSType        = as_u32_be(b"bgg4");     /* Bayer 14-bit Little-Endian, packed in 16-bits, ordered B G B G... alternating with G R G R... */
-pub const kCVPixelFormatType_14Bayer_GBRG: OSType        = as_u32_be(b"gbr4");     /* Bayer 14-bit Little-Endian, packed in 16-bits, ordered G B G B... alternating with R G R G... */
-pub const kCVPixelFormatType_DisparityFloat16: OSType    = as_u32_be(b"hdis");     /* IEEE754-2008 binary16 (half float), describing the normalized shift when comparing two images. Units are 1/meters: ( pixelShift / (pixelFocalLength * baselineInMeters) ) */
-pub const kCVPixelFormatType_DisparityFloat32: OSType    = as_u32_be(b"fdis");     /* IEEE754-2008 binary32 float, describing the normalized shift when comparing two images. Units are 1/meters: ( pixelShift / (pixelFocalLength * baselineInMeters) ) */
-pub const kCVPixelFormatType_DepthFloat16: OSType        = as_u32_be(b"hdep");     /* IEEE754-2008 binary16 (half float), describing the depth (distance to an object) in meters */
-pub const kCVPixelFormatType_DepthFloat32: OSType        = as_u32_be(b"fdep");     /* IEEE754-2008 binary32 float, describing the depth (distance to an object) in meters */
+pub const kCVPixelFormatType_ARGB2101010LEPacked: OSType = as_u32_be(b"l10r"); /* little-endian ARGB2101010 full-range ARGB */
+pub const kCVPixelFormatType_OneComponent16Half: OSType = as_u32_be(b"L00h"); /* 16 bit one component IEEE half-precision float, 16-bit little-endian samples */
+pub const kCVPixelFormatType_OneComponent32Float: OSType = as_u32_be(b"L00f"); /* 32 bit one component IEEE float, 32-bit little-endian samples */
+pub const kCVPixelFormatType_TwoComponent16Half: OSType = as_u32_be(b"2C0h"); /* 16 bit two component IEEE half-precision float, 16-bit little-endian samples */
+pub const kCVPixelFormatType_TwoComponent32Float: OSType = as_u32_be(b"2C0f"); /* 32 bit two component IEEE float, 32-bit little-endian samples */
+pub const kCVPixelFormatType_64RGBAHalf: OSType = as_u32_be(b"RGhA"); /* 64 bit RGBA IEEE half-precision float, 16-bit little-endian samples */
+pub const kCVPixelFormatType_128RGBAFloat: OSType = as_u32_be(b"RGfA"); /* 128 bit RGBA IEEE float, 32-bit little-endian samples */
+pub const kCVPixelFormatType_14Bayer_GRBG: OSType = as_u32_be(b"grb4"); /* Bayer 14-bit Little-Endian, packed in 16-bits, ordered G R G R... alternating with B G B G... */
+pub const kCVPixelFormatType_14Bayer_RGGB: OSType = as_u32_be(b"rgg4"); /* Bayer 14-bit Little-Endian, packed in 16-bits, ordered R G R G... alternating with G B G B... */
+pub const kCVPixelFormatType_14Bayer_BGGR: OSType = as_u32_be(b"bgg4"); /* Bayer 14-bit Little-Endian, packed in 16-bits, ordered B G B G... alternating with G R G R... */
+pub const kCVPixelFormatType_14Bayer_GBRG: OSType = as_u32_be(b"gbr4"); /* Bayer 14-bit Little-Endian, packed in 16-bits, ordered G B G B... alternating with R G R G... */
+pub const kCVPixelFormatType_DisparityFloat16: OSType = as_u32_be(b"hdis"); /* IEEE754-2008 binary16 (half float), describing the normalized shift when comparing two images. Units are 1/meters: ( pixelShift / (pixelFocalLength * baselineInMeters) ) */
+pub const kCVPixelFormatType_DisparityFloat32: OSType = as_u32_be(b"fdis"); /* IEEE754-2008 binary32 float, describing the normalized shift when comparing two images. Units are 1/meters: ( pixelShift / (pixelFocalLength * baselineInMeters) ) */
+pub const kCVPixelFormatType_DepthFloat16: OSType = as_u32_be(b"hdep"); /* IEEE754-2008 binary16 (half float), describing the depth (distance to an object) in meters */
+pub const kCVPixelFormatType_DepthFloat32: OSType = as_u32_be(b"fdep"); /* IEEE754-2008 binary32 float, describing the depth (distance to an object) in meters */
 pub const kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange: OSType = as_u32_be(b"x420"); /* 2 plane YCbCr10 4:2:0, each 10 bits in the MSBs of 16bits, video-range (luma=[64,940] chroma=[64,960]) */
 pub const kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange: OSType = as_u32_be(b"x422"); /* 2 plane YCbCr10 4:2:2, each 10 bits in the MSBs of 16bits, video-range (luma=[64,940] chroma=[64,960]) */
 pub const kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange: OSType = as_u32_be(b"x444"); /* 2 plane YCbCr10 4:4:4, each 10 bits in the MSBs of 16bits, video-range (luma=[64,940] chroma=[64,960]) */
-pub const kCVPixelFormatType_420YpCbCr10BiPlanarFullRange: OSType  = as_u32_be(b"xf20"); /* 2 plane YCbCr10 4:2:0, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
-pub const kCVPixelFormatType_422YpCbCr10BiPlanarFullRange: OSType  = as_u32_be(b"xf22"); /* 2 plane YCbCr10 4:2:2, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
-pub const kCVPixelFormatType_444YpCbCr10BiPlanarFullRange: OSType  = as_u32_be(b"xf44"); /* 2 plane YCbCr10 4:4:4, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
-
+pub const kCVPixelFormatType_420YpCbCr10BiPlanarFullRange: OSType = as_u32_be(b"xf20"); /* 2 plane YCbCr10 4:2:0, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
+pub const kCVPixelFormatType_422YpCbCr10BiPlanarFullRange: OSType = as_u32_be(b"xf22"); /* 2 plane YCbCr10 4:2:2, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
+pub const kCVPixelFormatType_444YpCbCr10BiPlanarFullRange: OSType = as_u32_be(b"xf44"); /* 2 plane YCbCr10 4:4:4, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
 
 pub const kCVPixelBufferLock_ReadOnly: CVPixelBufferLockFlags = 1;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct CVPlanarComponentInfo {
-    /// offset from main base address to base address of this plane, big-endian 
+    /// offset from main base address to base address of this plane, big-endian
     pub offset: i32,
     /// bytes per row of this plane, big-endian
     pub rowBytes: u32,
@@ -124,15 +115,15 @@ pub struct CVPlanarPixelBufferInfo_YCbCrBiPlanar {
     pub componentInfoCbCr: CVPlanarComponentInfo,
 }
 
-
-
-pub type CVPixelBufferReleaseBytesCallback = extern "C" fn (releaseRefCon: *mut c_void,
-                                                            baseAddress: *const *const c_void);
-pub type CVPixelBufferReleasePlanarBytesCallback = extern "C" fn (releaseRefCon: *mut c_void,
-                                                                 dataPtr: *const *const c_void,
-                                                                 dataSize: size_t,
-                                                                 numberOfPlanes: size_t,
-                                                                 planeAddresses: *const *const c_void);
+pub type CVPixelBufferReleaseBytesCallback =
+    extern "C" fn(releaseRefCon: *mut c_void, baseAddress: *const *const c_void);
+pub type CVPixelBufferReleasePlanarBytesCallback = extern "C" fn(
+    releaseRefCon: *mut c_void,
+    dataPtr: *const *const c_void,
+    dataSize: size_t,
+    numberOfPlanes: size_t,
+    planeAddresses: *const *const c_void,
+);
 
 extern "C" {
     pub static kCVPixelBufferPixelFormatTypeKey: CFStringRef;
@@ -154,13 +145,14 @@ extern "C" {
     pub static kCVPixelBufferOpenGLTextureCacheCompatibilityKey: CFStringRef;
     pub static kCVPixelBufferOpenGLESTextureCacheCompatibilityKey: CFStringRef;
 
-
     pub fn CVBufferGetTypeID() -> CFTypeID;
     pub fn CVPixelBufferRetain(texture: CVPixelBufferRef) -> CVPixelBufferRef;
     pub fn CVPixelBufferRelease(texture: CVPixelBufferRef);
-    pub fn CVPixelBufferCreateResolvedAttributesDictionary(allocator: CFAllocatorRef,
-                                                           attributes: CFArrayRef,
-                                                           resolvedDictionaryOut: *mut CFDictionaryRef) -> CVReturn;
+    pub fn CVPixelBufferCreateResolvedAttributesDictionary(
+        allocator: CFAllocatorRef,
+        attributes: CFArrayRef,
+        resolvedDictionaryOut: *mut CFDictionaryRef,
+    ) -> CVReturn;
     pub fn CVPixelBufferCreate(
         allocator: CFAllocatorRef,
         width: size_t,
@@ -189,31 +181,45 @@ extern "C" {
     //                                           planeBaseAddress: *const *const c_void,
     //                                           ) -> CVReturn;
 
-    pub fn CVPixelBufferLockBaseAddress(pixelBuffer: CVPixelBufferRef,
-                                        lockFlags: CVOptionFlags) -> CVReturn;
-    pub fn CVPixelBufferUnlockBaseAddress(pixelBuffer: CVPixelBufferRef,
-                                          unlockFlags: CVOptionFlags) -> CVReturn;
+    pub fn CVPixelBufferLockBaseAddress(
+        pixelBuffer: CVPixelBufferRef,
+        lockFlags: CVOptionFlags,
+    ) -> CVReturn;
+    pub fn CVPixelBufferUnlockBaseAddress(
+        pixelBuffer: CVPixelBufferRef,
+        unlockFlags: CVOptionFlags,
+    ) -> CVReturn;
     pub fn CVPixelBufferGetWidth(pixelBuffer: CVPixelBufferRef) -> size_t;
     pub fn CVPixelBufferGetHeight(pixelBuffer: CVPixelBufferRef) -> size_t;
     pub fn CVPixelBufferGetPixelFormatType(pixelBuffer: CVPixelBufferRef) -> OSType;
-    
+
     pub fn CVPixelBufferGetBaseAddress(pixelBuffer: CVPixelBufferRef) -> *mut c_void;
     pub fn CVPixelBufferGetBytesPerRow(pixelBuffer: CVPixelBufferRef) -> size_t;
     pub fn CVPixelBufferIsPlanar(pixelBuffer: CVPixelBufferRef) -> Boolean;
     pub fn CVPixelBufferGetPlaneCount(pixelBuffer: CVPixelBufferRef) -> size_t;
-    pub fn CVPixelBufferGetWidthOfPlane(pixelBuffer: CVPixelBufferRef,
-                                        planeIndex: size_t) -> size_t;
-    pub fn CVPixelBufferGetHeightOfPlane(pixelBuffer: CVPixelBufferRef,
-                                         planeIndex: size_t) -> size_t;
-    pub fn CVPixelBufferGetBaseAddressOfPlane(pixelBuffer: CVPixelBufferRef,
-                                              planeIndex: size_t) -> *mut c_void;
-    pub fn CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer: CVPixelBufferRef,
-                                              planeIndex: size_t) -> size_t;
+    pub fn CVPixelBufferGetWidthOfPlane(
+        pixelBuffer: CVPixelBufferRef,
+        planeIndex: size_t,
+    ) -> size_t;
+    pub fn CVPixelBufferGetHeightOfPlane(
+        pixelBuffer: CVPixelBufferRef,
+        planeIndex: size_t,
+    ) -> size_t;
+    pub fn CVPixelBufferGetBaseAddressOfPlane(
+        pixelBuffer: CVPixelBufferRef,
+        planeIndex: size_t,
+    ) -> *mut c_void;
+    pub fn CVPixelBufferGetBytesPerRowOfPlane(
+        pixelBuffer: CVPixelBufferRef,
+        planeIndex: size_t,
+    ) -> size_t;
 
-    pub fn CVPixelBufferGetExtendedPixels(pixelBuffer: CVPixelBufferRef,
-                                          extraColumnsOnLeft: *const size_t,
-                                          extraColumnsOnRight: *const size_t,
-                                          extraRowsOnTop: *const size_t,
-                                          extraRowsOnBottom: *const size_t);
+    pub fn CVPixelBufferGetExtendedPixels(
+        pixelBuffer: CVPixelBufferRef,
+        extraColumnsOnLeft: *const size_t,
+        extraColumnsOnRight: *const size_t,
+        extraRowsOnTop: *const size_t,
+        extraRowsOnBottom: *const size_t,
+    );
     pub fn CVPixelBufferFillExtendedPixels(pixelBuffer: CVPixelBufferRef) -> CVReturn;
 }

--- a/src/pixel_buffer_io_surface.rs
+++ b/src/pixel_buffer_io_surface.rs
@@ -1,4 +1,4 @@
-use crate::core_foundation_sys::{
+use core_foundation_sys::{
     base::{ CFAllocatorRef, },
     dictionary::CFDictionaryRef,
     string::CFStringRef,

--- a/src/pixel_buffer_io_surface.rs
+++ b/src/pixel_buffer_io_surface.rs
@@ -1,20 +1,11 @@
-use core_foundation_sys::{
-    base::{ CFAllocatorRef, },
-    dictionary::CFDictionaryRef,
-    string::CFStringRef,
-};
+use core_foundation_sys::{base::CFAllocatorRef, dictionary::CFDictionaryRef, string::CFStringRef};
 
-use crate::{
-    pixel_buffer::CVPixelBufferRef,
-    return_::CVReturn,
-};
-
+use crate::{pixel_buffer::CVPixelBufferRef, return_::CVReturn};
 
 // https://developer.apple.com/documentation/iosurface/iosurfaceref?language=objc
 #[derive(Debug, Copy, Clone)]
-pub enum _IOSurface { }
+pub enum _IOSurface {}
 pub type IOSurfaceRef = *mut _IOSurface;
-
 
 extern "C" {
     pub static kCVPixelBufferIOSurfaceOpenGLTextureCompatibilityKey: CFStringRef;
@@ -24,10 +15,11 @@ extern "C" {
     pub static kCVPixelBufferIOSurfaceOpenGLESTextureCompatibilityKey: CFStringRef;
     pub static kCVPixelBufferIOSurfaceOpenGLESFBOCompatibilityKey: CFStringRef;
 
-
     pub fn CVPixelBufferGetIOSurface(pixelBuffer: CVPixelBufferRef) -> IOSurfaceRef;
-    pub fn CVPixelBufferCreateWithIOSurface(allocator: CFAllocatorRef,
-                                            surface: IOSurfaceRef,
-                                            pixelBufferAttributes: CFDictionaryRef,
-                                            pixelBufferOut: *mut CVPixelBufferRef) -> CVReturn;
+    pub fn CVPixelBufferCreateWithIOSurface(
+        allocator: CFAllocatorRef,
+        surface: IOSurfaceRef,
+        pixelBufferAttributes: CFDictionaryRef,
+        pixelBufferOut: *mut CVPixelBufferRef,
+    ) -> CVReturn;
 }

--- a/src/pixel_buffer_pool.rs
+++ b/src/pixel_buffer_pool.rs
@@ -1,5 +1,5 @@
-use crate::libc::{ c_void, };
-use crate::core_foundation_sys::{
+use libc::{ c_void, };
+use core_foundation_sys::{
     base::{ CFAllocatorRef, CFTypeID, CFTypeRef },
     dictionary::CFDictionaryRef,
     string::CFStringRef,

--- a/src/pixel_buffer_pool.rs
+++ b/src/pixel_buffer_pool.rs
@@ -1,17 +1,11 @@
-use libc::{ c_void, };
 use core_foundation_sys::{
-    base::{ CFAllocatorRef, CFTypeID, CFTypeRef },
+    base::{CFAllocatorRef, CFTypeID, CFTypeRef},
     dictionary::CFDictionaryRef,
     string::CFStringRef,
 };
+use libc::c_void;
 
-use crate::{
-    base::CVOptionFlags,
-    pixel_buffer::CVPixelBufferRef,
-    return_::CVReturn,
-
-};
-
+use crate::{base::CVOptionFlags, pixel_buffer::CVPixelBufferRef, return_::CVReturn};
 
 pub type CVPixelBufferPoolRef = CFTypeRef;
 pub type CVPixelBufferPoolFlushFlags = CVOptionFlags;
@@ -28,19 +22,25 @@ extern "C" {
     pub fn CVPixelBufferPoolGetTypeID() -> CFTypeID;
     pub fn CVPixelBufferPoolRetain(pixelBufferPool: CVPixelBufferPoolRef) -> CVPixelBufferPoolRef;
     pub fn CVPixelBufferPoolRelease(pixelBufferPool: CVPixelBufferPoolRef) -> c_void;
-    pub fn CVPixelBufferPoolCreate(allocator: CFAllocatorRef,
-                                   poolAttributes: CFDictionaryRef,
-                                   pixelBufferAttributes: CFDictionaryRef,
-                                   poolOut: *mut CVPixelBufferPoolRef) -> CVReturn;
+    pub fn CVPixelBufferPoolCreate(
+        allocator: CFAllocatorRef,
+        poolAttributes: CFDictionaryRef,
+        pixelBufferAttributes: CFDictionaryRef,
+        poolOut: *mut CVPixelBufferPoolRef,
+    ) -> CVReturn;
     pub fn CVPixelBufferPoolGetAttributes(pool: CVPixelBufferPoolRef) -> CFDictionaryRef;
-    pub fn CVPixelBufferPoolGetPixelBufferAttributes(pool: CVPixelBufferPoolRef) -> CFDictionaryRef;
-    pub fn CVPixelBufferPoolCreatePixelBuffer(allocator: CFAllocatorRef,
-                                              pixelBufferPool: CVPixelBufferPoolRef,
-                                              pixelBufferOut: *mut CVPixelBufferRef) -> CVReturn;
-    pub fn CVPixelBufferPoolCreatePixelBufferWithAuxAttributes(allocator: CFAllocatorRef,
-                                                               pixelBufferPool: CVPixelBufferPoolRef,
-                                                               auxAttributes: CFDictionaryRef,
-                                                               pixelBufferOut: *mut CVPixelBufferRef) -> CVReturn;
-    pub fn CVPixelBufferPoolFlush(pool: CVPixelBufferPoolRef,
-                                  options: CVPixelBufferPoolFlushFlags);
+    pub fn CVPixelBufferPoolGetPixelBufferAttributes(pool: CVPixelBufferPoolRef)
+        -> CFDictionaryRef;
+    pub fn CVPixelBufferPoolCreatePixelBuffer(
+        allocator: CFAllocatorRef,
+        pixelBufferPool: CVPixelBufferPoolRef,
+        pixelBufferOut: *mut CVPixelBufferRef,
+    ) -> CVReturn;
+    pub fn CVPixelBufferPoolCreatePixelBufferWithAuxAttributes(
+        allocator: CFAllocatorRef,
+        pixelBufferPool: CVPixelBufferPoolRef,
+        auxAttributes: CFDictionaryRef,
+        pixelBufferOut: *mut CVPixelBufferRef,
+    ) -> CVReturn;
+    pub fn CVPixelBufferPoolFlush(pool: CVPixelBufferPoolRef, options: CVPixelBufferPoolFlushFlags);
 }

--- a/src/pixel_format_description.rs
+++ b/src/pixel_format_description.rs
@@ -1,5 +1,5 @@
-use crate::libc::{ c_void, };
-use crate::core_foundation_sys::{
+use libc::{ c_void, };
+use core_foundation_sys::{
     base::{ Boolean, CFAllocatorRef, CFIndex, },
     dictionary::CFDictionaryRef,
     array::CFArrayRef,

--- a/src/pixel_format_description.rs
+++ b/src/pixel_format_description.rs
@@ -1,20 +1,15 @@
-use libc::{ c_void, };
 use core_foundation_sys::{
-    base::{ Boolean, CFAllocatorRef, CFIndex, },
-    dictionary::CFDictionaryRef,
     array::CFArrayRef,
+    base::{Boolean, CFAllocatorRef, CFIndex},
+    dictionary::CFDictionaryRef,
     string::CFStringRef,
 };
+use libc::c_void;
 
-use crate::{
-    OSType,
-    pixel_buffer::CVPixelBufferRef,
-};
+use crate::{pixel_buffer::CVPixelBufferRef, OSType};
 
-
-pub type CVFillExtendedPixelsCallBack = extern "C" fn (pixelBuffer: CVPixelBufferRef,
-                                                       refCon: *mut c_void) -> Boolean;
-
+pub type CVFillExtendedPixelsCallBack =
+    extern "C" fn(pixelBuffer: CVPixelBufferRef, refCon: *mut c_void) -> Boolean;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -22,9 +17,7 @@ pub struct CVFillExtendedPixelsCallBackData {
     pub version: CFIndex,
     pub fillCallBack: CVFillExtendedPixelsCallBack,
     pub refCon: *mut c_void,
-
 }
-
 
 extern "C" {
     pub static kCVPixelFormatName: CFStringRef;
@@ -41,10 +34,10 @@ extern "C" {
     /// kCFBooleanTrue indicates that the format contains alpha and some images may be considered transparent
     /// kCFBooleanFalse indicates that there is no alpha and images are always opaque.
     pub static kCVPixelFormatContainsAlpha: CFStringRef;
-    
+
     /// kCFBooleanTrue indicates that the format contains YCbCr data
     pub static kCVPixelFormatContainsYCbCr: CFStringRef;
-    
+
     /// kCFBooleanTrue indicates that the format contains RGB data
     pub static kCVPixelFormatContainsRGB: CFStringRef;
 
@@ -58,10 +51,9 @@ extern "C" {
 
     /// All buffers have one or more image planes.
     /// Each plane may contain a single or an interleaved set of components
-    /// For simplicity sake, 
+    /// For simplicity sake,
     /// pixel formats that are not planar may place the required format keys at the top level dictionary.
     pub static kCVPixelFormatPlanes: CFStringRef;
-
 
     pub static kCVPixelFormatBlockWidth: CFStringRef;
     pub static kCVPixelFormatBlockHeight: CFStringRef;
@@ -70,14 +62,14 @@ extern "C" {
     /// For simple pixel formats this will be equivalent to the traditional bitsPerPixel value.
     pub static kCVPixelFormatBitsPerBlock: CFStringRef;
 
-    /// Used to state requirements on block multiples.  v210 would be '8' here for the horizontal case, 
+    /// Used to state requirements on block multiples.  v210 would be '8' here for the horizontal case,
     /// to match the standard v210 row alignment value of 48.
     /// These may be assumed as 1 if not present.
     pub static kCVPixelFormatBlockHorizontalAlignment: CFStringRef;
     pub static kCVPixelFormatBlockVerticalAlignment: CFStringRef;
 
     /// CFData containing the bit pattern for a block of black pixels.  If absent, black is assumed to be all zeros.
-    /// If present, this should be bitsPerPixel bits long -- if bitsPerPixel is less than a byte, repeat the bit pattern 
+    /// If present, this should be bitsPerPixel bits long -- if bitsPerPixel is less than a byte, repeat the bit pattern
     /// for the full byte.
     pub static kCVPixelFormatBlackBlock: CFStringRef;
 
@@ -103,14 +95,18 @@ extern "C" {
 
     pub static kCVPixelFormatFillExtendedPixelsCallback: CFStringRef;
 
-
-    pub fn CVPixelFormatDescriptionCreateWithPixelFormatType(allocator: CFAllocatorRef,
-                                                             pixelFormat: OSType) -> CFDictionaryRef;
-    pub fn CVPixelFormatDescriptionArrayCreateWithAllPixelFormatTypes(allocator: CFAllocatorRef) -> CFArrayRef;
-    pub fn CVPixelFormatDescriptionRegisterDescriptionWithPixelFormatType(description: CFDictionaryRef,
-                                                                          pixelFormat: OSType);
+    pub fn CVPixelFormatDescriptionCreateWithPixelFormatType(
+        allocator: CFAllocatorRef,
+        pixelFormat: OSType,
+    ) -> CFDictionaryRef;
+    pub fn CVPixelFormatDescriptionArrayCreateWithAllPixelFormatTypes(
+        allocator: CFAllocatorRef,
+    ) -> CFArrayRef;
+    pub fn CVPixelFormatDescriptionRegisterDescriptionWithPixelFormatType(
+        description: CFDictionaryRef,
+        pixelFormat: OSType,
+    );
 }
-
 
 #[cfg(feature = "direct3d")]
 extern "C" {

--- a/src/return_.rs
+++ b/src/return_.rs
@@ -1,31 +1,29 @@
-
 pub type CVReturn = i32;
 
-
-pub const kCVReturnSuccess: CVReturn                         = 0;
-pub const kCVReturnFirst: CVReturn                           = -6660;
-pub const kCVReturnError: CVReturn                           = kCVReturnFirst;
-pub const kCVReturnInvalidArgument: CVReturn                 = -6661;
-pub const kCVReturnAllocationFailed: CVReturn                = -6662;
-pub const kCVReturnUnsupported: CVReturn                     = -6663;
+pub const kCVReturnSuccess: CVReturn = 0;
+pub const kCVReturnFirst: CVReturn = -6660;
+pub const kCVReturnError: CVReturn = kCVReturnFirst;
+pub const kCVReturnInvalidArgument: CVReturn = -6661;
+pub const kCVReturnAllocationFailed: CVReturn = -6662;
+pub const kCVReturnUnsupported: CVReturn = -6663;
 
 // DisplayLink related errors
-pub const kCVReturnInvalidDisplay: CVReturn                  = -6670;
-pub const kCVReturnDisplayLinkAlreadyRunning: CVReturn       = -6671;
-pub const kCVReturnDisplayLinkNotRunning: CVReturn           = -6672;
-pub const kCVReturnDisplayLinkCallbacksNotSet: CVReturn      = -6673;
+pub const kCVReturnInvalidDisplay: CVReturn = -6670;
+pub const kCVReturnDisplayLinkAlreadyRunning: CVReturn = -6671;
+pub const kCVReturnDisplayLinkNotRunning: CVReturn = -6672;
+pub const kCVReturnDisplayLinkCallbacksNotSet: CVReturn = -6673;
 
 // Buffer related errors
-pub const kCVReturnInvalidPixelFormat: CVReturn              = -6680;
-pub const kCVReturnInvalidSize: CVReturn                     = -6681;
-pub const kCVReturnInvalidPixelBufferAttributes: CVReturn    = -6682;
-pub const kCVReturnPixelBufferNotOpenGLCompatible: CVReturn  = -6683;
-pub const kCVReturnPixelBufferNotMetalCompatible: CVReturn   = -6684;
+pub const kCVReturnInvalidPixelFormat: CVReturn = -6680;
+pub const kCVReturnInvalidSize: CVReturn = -6681;
+pub const kCVReturnInvalidPixelBufferAttributes: CVReturn = -6682;
+pub const kCVReturnPixelBufferNotOpenGLCompatible: CVReturn = -6683;
+pub const kCVReturnPixelBufferNotMetalCompatible: CVReturn = -6684;
 
 // Buffer Pool related errors
-pub const kCVReturnWouldExceedAllocationThreshold: CVReturn  = -6689;
-pub const kCVReturnPoolAllocationFailed: CVReturn            = -6690;
-pub const kCVReturnInvalidPoolAttributes: CVReturn           = -6691;
-pub const kCVReturnRetry: CVReturn                           = -6692;
+pub const kCVReturnWouldExceedAllocationThreshold: CVReturn = -6689;
+pub const kCVReturnPoolAllocationFailed: CVReturn = -6690;
+pub const kCVReturnInvalidPoolAttributes: CVReturn = -6691;
+pub const kCVReturnRetry: CVReturn = -6692;
 
-pub const kCVReturnLast: CVReturn                            = -669;
+pub const kCVReturnLast: CVReturn = -669;


### PR DESCRIPTION
Closes #16 
Closes #21

First commit:
Removes core-graphics entirely.
Disables all default dependencies.
Updates the usage syntax to Rust2018.
Unfortunately, still keeping the `metal` dependency around.

Second commit:
rustfmt. Can be reviewed separately.