### PR TITLE
Remove dependency on `objc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 cfg-if = "1.0"
 libc = "0.2"
-objc = "0.2"
 core-foundation-sys = "0.8"
 
 [dependencies.metal]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #[macro_use]
 extern crate cfg_if;
 extern crate libc;
-extern crate objc;
 extern crate core_foundation_sys;
 
 

--- a/src/open_gl_es_texture_cache.rs
+++ b/src/open_gl_es_texture_cache.rs
@@ -1,5 +1,4 @@
-use crate::libc::size_t;
-use crate::objc::runtime::Object;
+use crate::libc::{c_void, size_t};
 use crate::core_foundation_sys::{
     base::{ CFAllocatorRef, CFTypeRef },
     dictionary::CFDictionaryRef,
@@ -14,7 +13,7 @@ use crate::{
 
 
 pub type CVOpenGLESTextureCacheRef = CFTypeRef;
-pub type CVEAGLContext = *mut Object;
+pub type CVEAGLContext = *mut c_void;
 
 extern "C" {
     pub fn CVOpenGLESTextureCacheCreate(


### PR DESCRIPTION
A slight breaking change that simplifies the dependency tree. Similar to https://github.com/LuoZijun/rust-core-video-sys/pull/22